### PR TITLE
28 implement use case 16 manage displayed media

### DIFF
--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/controller/DisplayController.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/controller/DisplayController.java
@@ -1,13 +1,14 @@
 package com.cs5324.monitorbackend.controller;
 
+import com.cs5324.monitorbackend.entity.Media;
+import com.cs5324.monitorbackend.entity.MediaIdListDTO;
 import com.cs5324.monitorbackend.service.DisplayService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -19,8 +20,19 @@ public class DisplayController {
     @GetMapping("/media")
     public ResponseEntity<?> getMediaToDisplay(){
         Map<String,Object> response = new LinkedHashMap<>();
-        response.put("count", displayService.getMediaToDisplay().size());
-        response.put("media", displayService.getMediaToDisplay());
+        List<Media> displaySvcReturn = displayService.getMediaToDisplay();
+        response.put("count", displaySvcReturn.size());
+        response.put("media", displaySvcReturn);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/media")
+    public ResponseEntity<?> updateTaggedMedia(@RequestBody MediaIdListDTO listOfIds){
+        Map<String,Object> response = new LinkedHashMap<>();
+        List<String> newMediaIds = listOfIds.getNewMediaIds();
+        List<Media> displaySvcReturn = displayService.tagMediaForDisplay(newMediaIds);
+        response.put("count", displaySvcReturn.size());
+        response.put("taggedMedia", displaySvcReturn);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/controller/DisplayController.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/controller/DisplayController.java
@@ -2,12 +2,25 @@ package com.cs5324.monitorbackend.controller;
 
 import com.cs5324.monitorbackend.service.DisplayService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping(path = "/api/display", produces = "application/json")
 @RequiredArgsConstructor
 public class DisplayController {
     private final DisplayService displayService;
+
+    @GetMapping("/media")
+    public ResponseEntity<?> getMediaToDisplay(){
+        Map<String,Object> response = new LinkedHashMap<>();
+        response.put("count", displayService.getMediaToDisplay().size());
+        response.put("media", displayService.getMediaToDisplay());
+        return ResponseEntity.ok().body(response);
+    }
 }

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/controller/MediaController.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/controller/MediaController.java
@@ -1,5 +1,6 @@
 package com.cs5324.monitorbackend.controller;
 
+import com.cs5324.monitorbackend.entity.Media;
 import com.cs5324.monitorbackend.entity.MediaDTO;
 import com.cs5324.monitorbackend.service.MediaService;
 import lombok.RequiredArgsConstructor;
@@ -7,9 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 @Slf4j
 @RestController
@@ -47,6 +46,19 @@ public class MediaController {
         Map<String,Object> response = new LinkedHashMap<>();
         response.put("result", "successful");
         response.put("savedMedia", mediaService.createNewMediaEntry(mediaDTO));
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/populate")
+    public ResponseEntity<?> populateMedia(){
+        Map<String,Object> response = new LinkedHashMap<>();
+        List<Media> populatedMedia = mediaService.populate();
+        List<UUID> mediaIds = new ArrayList<>();
+        for(Media pMedia : populatedMedia){
+            mediaIds.add(pMedia.getId());
+        }
+        response.put("mediaIds", mediaIds);
+        response.put("mediaAdded", populatedMedia);
         return ResponseEntity.ok().body(response);
     }
 

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/controller/PostController.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/controller/PostController.java
@@ -35,6 +35,7 @@ public class PostController {
         } catch (Exception ex) {
             return ResponseEntity.internalServerError().body(null);
         }
+    }
 
     //localhost:8080/api/posts?userId=2bcc6af8-4c97-4afc-96af-b03a128e8a32
     @GetMapping

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/controller/UserController.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/controller/UserController.java
@@ -1,14 +1,26 @@
 package com.cs5324.monitorbackend.controller;
 
 import com.cs5324.monitorbackend.service.UserService;
-import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 @RestController
-@RequestMapping(path = "/api/display", produces = "application/json")
+@RequestMapping(path = "/api/users", produces = "application/json")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+
+    @GetMapping
+    public ResponseEntity<?> getAllUsers(){
+        Map<String,Object> response = new LinkedHashMap<>();
+        response.put("count", userService.getAllUsers().size());
+        response.put("users", userService.getAllUsers());
+        return ResponseEntity.ok().body(response);
+    }
 }

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/entity/Media.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/entity/Media.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class Media {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/entity/Media.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/entity/Media.java
@@ -4,9 +4,7 @@ import com.cs5324.monitorbackend.entity.enums.ItemStatus;
 import com.cs5324.monitorbackend.entity.enums.MediaType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -14,7 +12,8 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class Media {

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/entity/MediaIdListDTO.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/entity/MediaIdListDTO.java
@@ -1,0 +1,11 @@
+package com.cs5324.monitorbackend.entity;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MediaIdListDTO {
+    private int count;
+    private List<String> newMediaIds;
+}

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/entity/User.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/entity/User.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+@ToString
 public class User implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/repository/MediaRepository.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/repository/MediaRepository.java
@@ -1,12 +1,18 @@
 package com.cs5324.monitorbackend.repository;
 
 import com.cs5324.monitorbackend.entity.Media;
+import com.cs5324.monitorbackend.entity.enums.ItemStatus;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface MediaRepository extends JpaRepository<Media, UUID>{
 
+    List<Media> findByItemStatusIn(Collection<@NotNull ItemStatus> itemStatus);
+    List<Media> findByIsTaggedOrderByCreatedAtDesc(@NotNull Boolean isTagged);
 }

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/service/DisplayService.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/service/DisplayService.java
@@ -1,20 +1,57 @@
 package com.cs5324.monitorbackend.service;
 
-import jakarta.annotation.Resource;
+import com.cs5324.monitorbackend.entity.Event;
+import com.cs5324.monitorbackend.entity.Media;
+import com.cs5324.monitorbackend.entity.Post;
+import com.cs5324.monitorbackend.entity.enums.ItemStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class DisplayService{
-    @Resource
     private final PostService postService;
-    @Resource
     private final PageService pageService;
-    @Resource
     private final MediaService mediaService;
-    @Resource
     private final EventService eventService;
+
+    public List<Media> getMediaToDisplay(){
+        return mediaService.getAllMediaSortByCreatedDesc();
+    }
+
+    public List<Post> getPostToDisplay(){
+        //TODO: Create required method for posts
+        //return postService.getAllPosts();
+        return null;
+    }
+    public List<Event> getEventToDisplay(){
+        //TODO: Create required method for events
+        //return eventService.getAllEvents();
+        return null;
+    }
+
+    public List<Media> mediaEligibleForDisplay(){
+        return mediaService.getMediaByApprovalStatus(ItemStatus.APPROVED);
+    }
+
+    public List<Media> tagMediaForDisplay(List<Media> newTaggedMedia){
+        List<Media> currentTaggedMedia = mediaService.getMediaByTagStatus();
+
+        boolean listMatchStatus = true;
+        for(Media newMedia : newTaggedMedia){
+            if (!currentTaggedMedia.contains(newMedia)) {
+                listMatchStatus = false;
+                break;
+            }
+        }
+        if(listMatchStatus){
+            return mediaService.updateTagStatus(newTaggedMedia, currentTaggedMedia);
+        } else {
+            return currentTaggedMedia;
+        }
+    }
 }

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/service/DisplayService.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/service/DisplayService.java
@@ -4,6 +4,7 @@ import com.cs5324.monitorbackend.entity.Event;
 import com.cs5324.monitorbackend.entity.Media;
 import com.cs5324.monitorbackend.entity.Post;
 import com.cs5324.monitorbackend.entity.enums.ItemStatus;
+import jakarta.mail.FetchProfile;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,7 +21,14 @@ public class DisplayService{
     private final EventService eventService;
 
     public List<Media> getMediaToDisplay(){
-        return mediaService.getAllMediaSortByCreatedDesc();
+        List<Media> eligibleMedia = mediaService.getMediaByTagStatus();
+        if(eligibleMedia.size() < 10){
+            List<Media> sortedMedia = mediaService.getMediaByApprovalStatus(ItemStatus.APPROVED);
+            while(eligibleMedia.size() < 10){
+                eligibleMedia.add(sortedMedia.remove(0));
+            }
+        }
+        return eligibleMedia;
     }
 
     public List<Post> getPostToDisplay(){

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/service/DisplayService.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/service/DisplayService.java
@@ -25,7 +25,7 @@ public class DisplayService{
         List<Media> taggedMedia = mediaService.getMediaByTagStatus();
         log.info("taggedMedia Size: {}", taggedMedia.size());
         if(taggedMedia.size() < 10){
-            List<Media> sortedMedia = mediaService.getMediaByApprovalStatus(ItemStatus.APPROVED);
+            List<Media> sortedMedia = mediaEligibleForDisplay();
             for(Media tagged : taggedMedia){
                 sortedMedia.remove(tagged);
             }
@@ -47,7 +47,7 @@ public class DisplayService{
         return null;
     }
 
-    public List<Media> mediaEligibleForDisplay(){
+    private List<Media> mediaEligibleForDisplay(){
         return mediaService.getMediaByApprovalStatus(ItemStatus.APPROVED);
     }
 

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/service/MediaService.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/service/MediaService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Slf4j
@@ -34,6 +35,24 @@ public class MediaService{
         }
         return mediaRepo.save(newMedia);
     }
+    public List<Media> populate() {
+        List<Media> populatedMedia = new ArrayList<>();
+        int numberToCreate = 10;
+        for(int i = 0; i < numberToCreate; i++){
+            populatedMedia.add(populateSingleMediaImage(i));
+        }
+        return populatedMedia;
+    }
+
+    private Media populateSingleMediaImage(int count) {
+        Media newMedia = new Media();
+        newMedia.setMediaType(MediaType.IMAGE);
+        newMedia.setLink("Dummy link " + count);
+        newMedia.setTitle("Dummy Title " + count);
+        newMedia.setItemStatus(ItemStatus.APPROVED);
+        return mediaRepo.save(newMedia);
+    }
+
     //READ
     public List<Media> getAllMediaSortByCreatedDesc(){
         return mediaRepo.findAll(Sort.by(Sort.Direction.DESC, "createdAt"));
@@ -52,7 +71,7 @@ public class MediaService{
     }
     public List<Media> getMediaByApprovalStatus(ItemStatus status) {
         List<Media> approvedMedia = mediaRepo.findByItemStatusIn(List.of(status));
-        approvedMedia.sort(Comparator.comparing(Media::getCreatedAt));
+        approvedMedia.sort(Comparator.comparing(Media::getCreatedAt).reversed());
         return approvedMedia;
     }
     public List<Media> getMediaByTagStatus() {
@@ -78,13 +97,16 @@ public class MediaService{
     public List<Media> updateTagStatus(List<Media> newTagged, List<Media> oldTagged) {
 
         for(Media oldMedia : oldTagged){
+            log.info("Updating oldMedia: {}", oldMedia);
             oldMedia.setIsTagged(false);
             mediaRepo.save(oldMedia);
         }
 
         List<Media> confirmationMedia = new LinkedList<>();
         for(Media newMedia : newTagged){
+            log.info("Updating newMedia: {}", newMedia);
             newMedia.setIsTagged(true);
+            newMedia.setUpdatedAt(LocalDateTime.now());
             confirmationMedia.add(mediaRepo.save(newMedia));
         }
 
@@ -97,6 +119,8 @@ public class MediaService{
         //TODO: need to add handling once media is tied to posts/users/display/etc
         mediaRepo.deleteById(mediaId);
     }
+
+
 
 
     //PROTECTED

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/service/MediaService.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/service/MediaService.java
@@ -13,9 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 @Slf4j
 @Service
@@ -52,6 +50,14 @@ public class MediaService{
     public List<Media> getMediaByType(String mediaType){
         return null;
     }
+    public List<Media> getMediaByApprovalStatus(ItemStatus status) {
+        List<Media> approvedMedia = mediaRepo.findByItemStatusIn(List.of(status));
+        approvedMedia.sort(Comparator.comparing(Media::getCreatedAt));
+        return approvedMedia;
+    }
+    public List<Media> getMediaByTagStatus() {
+        return mediaRepo.findByIsTaggedOrderByCreatedAtDesc(true);
+    }
     //UPDATE
     public Media updateMedia(UUID mediaId, MediaDTO mediaDTO){
         log.info("Updating existing media entry");
@@ -69,12 +75,29 @@ public class MediaService{
         }
         return mediaRepo.save(mediaToUpdate);
     }
+    public List<Media> updateTagStatus(List<Media> newTagged, List<Media> oldTagged) {
+
+        for(Media oldMedia : oldTagged){
+            oldMedia.setIsTagged(false);
+            mediaRepo.save(oldMedia);
+        }
+
+        List<Media> confirmationMedia = new LinkedList<>();
+        for(Media newMedia : newTagged){
+            newMedia.setIsTagged(true);
+            confirmationMedia.add(mediaRepo.save(newMedia));
+        }
+
+        return confirmationMedia;
+
+    }
     //DELETE
     public void deleteMedia(UUID mediaId){
         log.info("deleting existing media entry");
         //TODO: need to add handling once media is tied to posts/users/display/etc
         mediaRepo.deleteById(mediaId);
     }
+
 
     //PROTECTED
     //PRIVATE

--- a/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/service/UserService.java
+++ b/source_code/backend/CS_department_monitor_backend/src/main/java/com/cs5324/monitorbackend/service/UserService.java
@@ -6,6 +6,7 @@ import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -15,6 +16,9 @@ public class UserService {
     @Resource
     private UserRepository userRepository;
 
+    public List<User> getAllUsers(){
+        return userRepository.findAll();
+    }
     public Optional<User> getUser(UUID uuid) {
         return userRepository.findById(uuid);
     }


### PR DESCRIPTION
Have added endpoints for use in Postman as well.  Display posts return 10 eligible posts for display, priortizes tagged posts, then pulls the latest created images.  Utilize the new /media/populate endpoint to add 10 approved media entries (approval required for it to be eligible for display)